### PR TITLE
Add GitHub CLI authentication aliases for easier auth management

### DIFF
--- a/aliases.zsh
+++ b/aliases.zsh
@@ -166,6 +166,14 @@ alias sshkm-list='~/dotfiles/scripts/ssh-key-manager list'
 alias sshkm-test='~/dotfiles/scripts/ssh-key-manager test'
 alias sshkm-migrate='~/dotfiles/scripts/ssh-key-manager migrate'
 
+# GitHub CLI Authentication
+alias ghs='gh auth status'
+alias ghl='gh auth login'
+alias ghlo='gh auth logout'
+alias ghsw='gh auth switch'
+alias ghr='gh auth refresh'
+alias ght='gh auth token'
+
 # Tmux aliases
 alias ta='tmux attach -t'
 alias tad='tmux attach -d -t'


### PR DESCRIPTION
Added convenient aliases for GitHub CLI authentication commands:
- ghs: Check authentication status (gh auth status)
- ghl: Login to GitHub (gh auth login)
- ghlo: Logout from GitHub (gh auth logout)
- ghsw: Switch between GitHub accounts (gh auth switch)
- ghr: Refresh authentication (gh auth refresh)
- ght: Display authentication token (gh auth token)

These shortcuts make it easier to manage multiple GitHub accounts alongside the git profile management system.