### PR TITLE
chore: add Antigravity PATH configuration

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -86,3 +86,6 @@ export HERD_PHP_81_INI_SCAN_DIR="/Users/gerwin/Library/Application Support/Herd/
 
 # Herd injected PHP 8.5 configuration.
 export HERD_PHP_85_INI_SCAN_DIR="/Users/gerwin/Library/Application Support/Herd/config/php/85/"
+
+# Added by Antigravity
+export PATH="/Users/gerwin/.antigravity/antigravity/bin:$PATH"


### PR DESCRIPTION
## Summary
- Add Antigravity PATH configuration to .zshrc

## Changes
- Updated `.zshrc` to include Antigravity bin directory in PATH

## Technical Details
- Adds `/Users/gerwin/.antigravity/antigravity/bin` to PATH environment variable
- Enables Antigravity CLI tool availability in shell sessions

## Files Changed
- `.zshrc` - Added Antigravity PATH export