### PR TITLE
docs: add OpenCode to AI Development Tools

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -79,10 +79,11 @@ brew "oven-sh/bun/bun" # Fast all-in-one JavaScript runtime
 
 # AI Development Tools
 # Note: These require API keys to be set in your environment
-# See docs/ai-tools/AI.md for setup instructions
+# See docs/ai-tools/INSTALLATION.md for setup instructions
 cask "claude-code" # Claude Code - AI pair programming by Anthropic
 brew "gemini-cli" # Google Gemini CLI
 cask "codex" # OpenAI Codex application
+brew "opencode" # OpenCode - Terminal-based AI coding assistant
 
 # macOS Applications
 cask "aldente" # macOS battery charge limiter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- OpenCode terminal-based AI coding assistant to Brewfile
+  - Added `brew "opencode"` to AI Development Tools section
+  - Updated `docs/ai-tools/INSTALLATION.md` with OpenCode setup instructions
+  - OpenCode supports multiple providers (Anthropic, OpenAI, Google)
+  - Configuration via `~/.config/opencode/config.json`
+
 - Added modern web development terms to IT Dictionary:
   - **Astro** - Modern static site builder using Island Architecture
   - **HTMX** - Library for building modern UIs with HTML attributes

--- a/docs/ai-tools/INSTALLATION.md
+++ b/docs/ai-tools/INSTALLATION.md
@@ -1,6 +1,6 @@
 # AI CLI Tools Installation Guide
 
-This guide will help you install and configure Claude, Gemini, and Codex CLI tools on your system.
+This guide will help you install and configure Claude, Gemini, Codex, and OpenCode CLI tools on your system.
 
 ## Quick Installation
 
@@ -14,7 +14,7 @@ Run the Homebrew installation script which includes an option to install AI tool
 
 The script will:
 1. Install or update Homebrew
-2. Prompt you to install AI CLI tools (Claude, Gemini, Codex)
+2. Prompt you to install AI CLI tools (Claude, Gemini, Codex, OpenCode)
 3. Optionally configure API keys immediately
 
 ### Option 2: Manual Installation
@@ -30,6 +30,9 @@ brew install gemini-cli
 
 # Install Codex (as a cask application)
 brew install --cask codex
+
+# Install OpenCode (terminal-based AI coding assistant)
+brew install opencode
 ```
 
 Then configure API keys:
@@ -72,6 +75,16 @@ Then run the setup script to configure API keys:
 2. Sign up or log in
 3. Create a new secret key
 4. Save the key immediately (it won't be shown again)
+
+### OpenCode
+OpenCode supports multiple providers. Configure the API key for your preferred provider:
+- **Anthropic**: Use `ANTHROPIC_API_KEY` (same as Claude)
+- **OpenAI**: Use `OPENAI_API_KEY` (same as Codex)
+- **Google**: Use `GEMINI_API_KEY` (same as Gemini)
+
+Configuration file: `~/.config/opencode/config.json`
+
+For more details, visit: https://opencode.ai/docs
 
 ## Configuration
 
@@ -120,11 +133,13 @@ Test your installation:
 command -v claude && echo "Claude: ✓" || echo "Claude: ✗"
 command -v gemini && echo "Gemini: ✓" || echo "Gemini: ✗"
 command -v codex && echo "Codex: ✓" || echo "Codex: ✗"
+command -v opencode && echo "OpenCode: ✓" || echo "OpenCode: ✗"
 
 # Check versions
 claude --version
 gemini --version
 codex --version
+opencode --version
 ```
 
 ## Troubleshooting
@@ -172,6 +187,7 @@ brew update && brew upgrade
 brew upgrade --cask claude-code
 brew upgrade gemini-cli
 brew upgrade --cask codex
+brew upgrade opencode
 ```
 
 ## Uninstallation
@@ -182,6 +198,7 @@ Remove AI tools:
 brew uninstall --cask claude-code
 brew uninstall gemini-cli
 brew uninstall --cask codex
+brew uninstall opencode
 ```
 
 Remove API keys from `~/.zshrc.private`:


### PR DESCRIPTION
## Summary
- Add OpenCode terminal-based AI coding assistant to the Brewfile alongside existing AI tools (Claude, Gemini, Codex)
- Update installation documentation with OpenCode setup instructions

## Changes

### Brewfile
- Added `brew "opencode"` to AI Development Tools section
- Fixed comment to reference `docs/ai-tools/INSTALLATION.md` instead of `AI.md`

### docs/ai-tools/INSTALLATION.md
- Added OpenCode installation command
- Added OpenCode API key configuration section (supports Anthropic, OpenAI, Google providers)
- Added OpenCode to verification commands
- Added OpenCode to update and uninstall commands

### CHANGELOG.md
- Documented OpenCode addition under `[Unreleased]`

## Installation
```bash
brew install opencode
opencode --version
```

## Related
Closes #96