### PR TITLE
feat: Add Obsidian to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -122,6 +122,7 @@ cask "lastpass" # Password manager
 cask "logi-options+" # Software for Logitech devices (new version)
 cask "macs-fan-control" # Control fans on Apple computers
 cask "notion" # All-in-one workspace for notes and collaboration
+cask "obsidian" # Knowledge base that works on local Markdown files
 cask "opera" # Web browser with built-in VPN
 cask "postman" # API development and testing platform
 cask "rustdesk" # Remote desktop software

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Obsidian knowledge management application to Brewfile
+  - Added `cask "obsidian"` to macOS Applications section
+  - Local-first Markdown-based knowledge base
+  - Complements existing productivity tools (Notion, AppFlowy)
+
 - OpenCode terminal-based AI coding assistant to Brewfile
   - Added `brew "opencode"` to AI Development Tools section
   - Updated `docs/ai-tools/INSTALLATION.md` with OpenCode setup instructions


### PR DESCRIPTION
## Summary
- Add Obsidian knowledge management application to Brewfile for local-first, Markdown-based note-taking

## Changes
- Added `cask "obsidian"` to macOS Applications section in alphabetical order
- Updated `CHANGELOG.md` with Obsidian addition entry

## Motivation
Obsidian is a powerful knowledge base application that:
- Works on top of local Markdown files (local-first data)
- Uses developer-friendly Markdown format
- Supports cross-machine sync via Git or cloud services
- Has a rich plugin ecosystem for customization
- Complements existing productivity tools (Notion, AppFlowy)

## Testing
```bash
# Verify cask is available
brew info --cask obsidian

# Install via Brewfile
brew bundle install --file=Brewfile

# Verify installation
ls /Applications/Obsidian.app
```

## Cask Information
| Property | Value |
|----------|-------|
| Cask Token | `obsidian` |
| Version | 1.10.6 (auto_updates) |
| 30-day Installs | 7,728 |

Closes #98