### PR TITLE
feat(clickup): add comment management commands

### DIFF
--- a/docs/limitations/100-clickup-comment-reactions.md
+++ b/docs/limitations/100-clickup-comment-reactions.md
@@ -1,0 +1,101 @@
+# ClickUp API Limitation: Comment Reactions
+
+## Issue Reference
+- GitHub Issue: [#100](https://github.com/iamgerwin/dotfiles/issues/100)
+- Date Documented: 2025-12-16
+
+## Summary
+
+The ClickUp API v2 does not provide documented endpoints for adding or managing emoji reactions on comments. This is a feature that exists in the ClickUp web and mobile UI but is not exposed through the public API.
+
+## Requested Feature
+
+Add the ability to:
+1. Add emoji reactions to comments (e.g., `:white_check_mark:`, `:+1:`, `:eyes:`)
+2. Remove emoji reactions from comments
+3. List reactions on a comment
+
+## API Investigation
+
+### Endpoints Checked
+- `GET /task/{task_id}/comment` - Returns comments but no reaction data in response
+- `PUT /comment/{comment_id}` - Supports `resolved` and `assignee` but not `reactions`
+- No documented `/comment/{comment_id}/reaction` endpoint exists
+
+### Official Documentation References
+- [Update Comment API](https://developer.clickup.com/reference/updatecomment)
+- [Get Task Comments API](https://developer.clickup.com/reference/gettaskcomments)
+- [ClickUp Comments Overview](https://developer.clickup.com/docs/comments)
+
+### What IS Supported
+The following comment management features ARE available via the API:
+- `resolve-comment` - Mark a comment as resolved
+- `unresolve-comment` - Mark a comment as unresolved
+- `assign-comment` - Assign a comment to a user
+- `unassign-comment` - Remove assignment from a comment
+
+## Workarounds
+
+### Option 1: Use Text-Based Reactions
+Instead of emoji reactions, add a reply comment with the reaction:
+```bash
+./clickup-api.sh add-comment TASK_ID "Acknowledged"
+```
+
+### Option 2: Use Resolve Status
+For acknowledgment purposes, use the resolve feature:
+```bash
+./clickup-api.sh resolve-comment COMMENT_ID
+```
+
+### Option 3: Use Comment Assignment
+Assign the comment to indicate someone is handling it:
+```bash
+./clickup-api.sh assign-comment COMMENT_ID USER_ID
+```
+
+## Potential Future Solutions
+
+1. **ClickUp Feature Request**: Submit a feature request to ClickUp for API support for comment reactions
+   - [ClickUp Feature Requests Portal](https://clickup.canny.io/)
+
+2. **Undocumented Endpoints**: There may be undocumented API endpoints that support reactions (common in evolving APIs)
+   - Risk: Undocumented endpoints may change without notice
+
+3. **Webhooks**: Monitor for reaction events via webhooks (if available) for read-only access
+
+## Impact
+
+| Use Case | Workaround Available |
+|----------|---------------------|
+| Quick acknowledgment | Use `resolve-comment` |
+| Assign for follow-up | Use `assign-comment` |
+| Express agreement/disagreement | Add text comment reply |
+| Track reaction counts | Not available |
+
+## Status
+
+**LIMITATION CONFIRMED** - As of December 2025, the ClickUp API v2 does not support comment reactions.
+
+## Related Commands Implemented
+
+Despite the reaction limitation, the following comment management commands were implemented:
+
+```bash
+# Mark comment as resolved
+./clickup-api.sh resolve-comment COMMENT_ID
+
+# Mark comment as unresolved
+./clickup-api.sh unresolve-comment COMMENT_ID
+
+# Assign comment to user
+./clickup-api.sh assign-comment COMMENT_ID USER_ID
+
+# Unassign comment
+./clickup-api.sh unassign-comment COMMENT_ID
+```
+
+## Changelog
+
+- **2025-12-16**: Initial documentation created
+- **2025-12-16**: Implemented resolve, unresolve, assign, and unassign comment commands as partial solution

--- a/scripts/clickup/README.md
+++ b/scripts/clickup/README.md
@@ -25,7 +25,7 @@ Comprehensive bash scripts for interacting with the ClickUp API, providing task 
 ## Features
 
 - **Comprehensive Task Management**: Create, update, search, and batch manage tasks
-- **Comment System**: Add comments and retrieve full conversation threads with replies
+- **Comment System**: Add comments, retrieve threads with replies, resolve/unresolve comments, and assign comments to users
 - **Attachment Handling**: Download individual attachments or batch download all images
 - **Secure Configuration**: Environment-based API key management
 - **Error Handling**: Robust error detection with informative messages
@@ -214,6 +214,18 @@ Priority levels:
 ./clickup-api.sh add-comment TASK_ID "Found root cause:
 - Database connection timeout
 - Need to increase connection pool size"
+
+# Mark a comment as resolved (acknowledged/completed)
+./clickup-api.sh resolve-comment COMMENT_ID
+
+# Mark a comment as unresolved (reopen for discussion)
+./clickup-api.sh unresolve-comment COMMENT_ID
+
+# Assign a comment to a team member for follow-up
+./clickup-api.sh assign-comment COMMENT_ID USER_ID
+
+# Unassign a comment
+./clickup-api.sh unassign-comment COMMENT_ID
 ```
 
 ### Attachments
@@ -314,6 +326,10 @@ Priority levels:
 |---------|-------------|---------|
 | `get-comments` | Get all comments with replies | `./clickup-api.sh get-comments TASK_ID` |
 | `add-comment` | Add comment to task | `./clickup-api.sh add-comment TASK_ID "text"` |
+| `resolve-comment` | Mark comment as resolved | `./clickup-api.sh resolve-comment COMMENT_ID` |
+| `unresolve-comment` | Mark comment as unresolved | `./clickup-api.sh unresolve-comment COMMENT_ID` |
+| `assign-comment` | Assign comment to user | `./clickup-api.sh assign-comment COMMENT_ID USER_ID` |
+| `unassign-comment` | Unassign comment from user | `./clickup-api.sh unassign-comment COMMENT_ID` |
 | `get-attachments` | List task attachments | `./clickup-api.sh get-attachments TASK_ID` |
 | `download-attachment` | Download specific attachment | `./clickup-api.sh download-attachment TASK_ID ATTACH_ID` |
 | `auto-download-images` | Download all image attachments | `./clickup-api.sh auto-download-images TASK_ID` |


### PR DESCRIPTION
## Summary

Add new comment management capabilities to `clickup-api.sh`:
- Mark comments as resolved/unresolved
- Assign/unassign comments to users

## Changes

### New Commands
| Command | Description |
|---------|-------------|
| `resolve-comment COMMENT_ID` | Mark comment as resolved |
| `unresolve-comment COMMENT_ID` | Mark comment as unresolved |
| `assign-comment COMMENT_ID USER_ID` | Assign comment to user |
| `unassign-comment COMMENT_ID` | Unassign comment from user |

### Files Changed
- `scripts/clickup/clickup-api.sh` - Added 4 new commands, bumped version to 2.2.0
- `scripts/clickup/README.md` - Updated documentation with new commands and examples
- `docs/limitations/100-clickup-comment-reactions.md` - Documented API limitation for emoji reactions

## API Limitation

Comment reactions (emoji like `:white_check_mark:`) are **not supported** by the ClickUp API v2. This limitation has been documented with workarounds.

## Test Plan

- [ ] Verify script syntax: `bash -n scripts/clickup/clickup-api.sh`
- [ ] Test help output: `./scripts/clickup/clickup-api.sh --help`
- [ ] Test resolve-comment with valid COMMENT_ID
- [ ] Test unresolve-comment with valid COMMENT_ID
- [ ] Test assign-comment with valid COMMENT_ID and USER_ID
- [ ] Test unassign-comment with valid COMMENT_ID

Closes #100