### PR TITLE
docs(dictionary): add ADR and Golden Path terms

### DIFF
--- a/docs/dictionary.md
+++ b/docs/dictionary.md
@@ -61,6 +61,12 @@ A comprehensive glossary of IT terminology for developers, designers, PMs, QA en
 **Description:** A structural design pattern that allows objects with incompatible interfaces to work together. It acts as a wrapper that translates one interface into another that clients expect.
 **Related Terms:** Decorator Pattern, Factory Pattern
 
+### ADR (Architecture Decision Record)
+
+**Category:** Software Architecture / Documentation
+**Description:** A document that captures an important architectural decision made along with its context and consequences. ADRs provide a structured format for recording why specific technical choices were made, including the problem being addressed, considered alternatives, decision rationale, and anticipated trade-offs. They serve as institutional memory, helping current and future team members understand the reasoning behind architecture choices. ADRs are typically stored in version control alongside code, often in a docs/decisions or docs/adr directory, using lightweight templates like Michael Nygard's original format or MADR (Markdown Any Decision Records).
+**Related Terms:** Technical Debt, DDD, System Design, Documentation, Software Architecture, SDLC
+
 ### Acceptance Testing
 
 **Category:** Testing / QA
@@ -1266,6 +1272,12 @@ A comprehensive glossary of IT terminology for developers, designers, PMs, QA en
 **Category:** Programming Language
 **Description:** A statically typed, compiled programming language designed by Google emphasizing simplicity, concurrency, and performance. Go features garbage collection, built-in concurrency primitives (goroutines and channels), and fast compilation times.
 **Related Terms:** Rust, Concurrency, Microservices
+
+### Golden Path
+
+**Category:** Platform Engineering / DevOps
+**Description:** A well-documented, standardized, and supported way to accomplish common development tasks within an organization, providing an opinionated but flexible approach that reduces cognitive load and accelerates delivery. Golden paths (also called "paved roads" or "golden routes") represent the recommended way to build, deploy, and operate services—not mandatory constraints, but paths of least resistance with built-in best practices, security controls, and observability. Platform engineering teams create golden paths for activities like creating new services, setting up CI/CD pipelines, provisioning infrastructure, and configuring monitoring. Developers can deviate when necessary but benefit from reduced friction and guaranteed support when following the golden path.
+**Related Terms:** Platform Engineering, Developer Experience (DX), DevOps, Internal Developer Portal, GitOps, Infrastructure as Code
 
 ### God Object
 
@@ -3433,4 +3445,4 @@ To add new terms to this dictionary:
 
 ---
 
-*Last updated: December 14, 2025 03:44 (Asia/Manila)*
+*Last updated: December 19, 2025 16:45 (Asia/Manila)*


### PR DESCRIPTION
## Summary

- Add two new IT jargon terms to the dictionary, maintaining alphabetical order
- **ADR (Architecture Decision Record)** - Software architecture documentation standard for capturing technical decisions
- **Golden Path** - Platform engineering concept for standardized development workflows

## Changes

| Term | Section | Category |
|------|---------|----------|
| ADR (Architecture Decision Record) | A | Software Architecture / Documentation |
| Golden Path | G | Platform Engineering / DevOps |

## Notes

- Both terms are widely used in modern software engineering practices
- ADR is increasingly adopted for maintaining architectural decision history
- Golden Path is a key concept in platform engineering and developer experience