### PR TITLE
feat: add OrbStack to Brewfile as Docker Desktop alternative

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -92,6 +92,7 @@ cask "appflowy" # Open-source alternative to Notion
 cask "arc" # Recursively search directories for a regex pattern
 cask "discord" # Voice and text chat for communities
 cask "docker-desktop" # Application for building and sharing containerized applications
+cask "orbstack" # Fast, lightweight alternative to Docker Desktop
 cask "dotnet-runtime" # Microsoft .NET runtime
 cask "firefox@developer-edition" # Web browser for developers
 cask "flutter" # UI toolkit for building natively compiled applications

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Migration Notes
 **For MAMP/XAMPP users:**
 - Consider using **Laravel Herd** for PHP development (already installed)
-- Alternative: Use **Docker Desktop** (already installed) for full-stack environments
+- Alternative: Use **Docker Desktop** or **OrbStack** (both installed) for full-stack environments
+- OrbStack is faster and more lightweight than Docker Desktop
 - Herd provides better performance and modern PHP version management
 
 **For Python version management:**

--- a/README.md
+++ b/README.md
@@ -710,7 +710,7 @@ dotnet --version            # Check .NET version
 - Configures the shell environment for .NET development.
 - Optional script to install and trust development certificates for HTTPS.
 
-**Note:** For local development environments previously using MAMP or XAMPP, consider using Laravel Herd for PHP development or Docker containers for full-stack applications.
+**Note:** For local development environments previously using MAMP or XAMPP, consider using Laravel Herd for PHP development or Docker containers (Docker Desktop or OrbStack) for full-stack applications. OrbStack is recommended for better performance and lower resource usage.
 
 ### AI Prompts Management
 


### PR DESCRIPTION
## Summary
- Add OrbStack cask to Brewfile as a lightweight Docker Desktop alternative
- Update documentation to recommend OrbStack for better performance and lower resource usage

## Changes Made

### Brewfile
- Added `cask "orbstack"` next to docker-desktop (line 95)
- OrbStack provides faster containerization with significantly lower system overhead

### Documentation Updates
- **CHANGELOG.md**: Updated migration notes to mention OrbStack alongside Docker Desktop
- **README.md**: Added recommendation to use OrbStack for better performance

## Benefits of OrbStack
- **Faster performance**: OrbStack launches and runs containers 2-10x faster than Docker Desktop
- **Lower resource usage**: Uses significantly less CPU and memory than Docker Desktop
- **Better macOS integration**: Native macOS virtualization with Rosetta support for ARM/Intel compatibility
- **Seamless Docker compatibility**: Fully compatible with Docker CLI and Docker Compose

## Testing
To verify OrbStack installation:
```bash
# Install from Brewfile
brew bundle install

# Verify OrbStack is installed
orb --version

# Test Docker compatibility (OrbStack provides docker CLI)
docker --version
docker ps
```

## Related
- OrbStack website: https://orbstack.dev
- Docs can be referenced in future for setup/configuration if needed