### PR TITLE
Add crush brew installation

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,6 @@
 # Taps
 tap "aws/tap" # AWS tools
+tap "charmbracelet/tap" # Charm shell tools and utilities
 tap "oven-sh/bun" # Bun JavaScript runtime
 
 # Command Line Tools & Development
@@ -7,8 +8,10 @@ brew "bat" # Cat clone with syntax highlighting
 brew "bottom" # Yet another cross-platform graphical process/system monitor
 brew "btop" # Resource monitor that shows usage and stats
 brew "chezmoi" # Manage your dotfiles across multiple machines
+brew "charmbracelet/tap/crush" # Compress URLs to make them shareable
 
 # Elixir Development
+brew "mise" # Fast and flexible tool version manager
 brew "asdf" # Extendable version manager for multiple languages
 brew "autoconf" # Automatic configure script builder (Erlang dependency)
 brew "wxwidgets" # Cross-platform GUI toolkit (Erlang dependency)


### PR DESCRIPTION
## Description

This PR adds two utility packages from Homebrew to enhance development and URL management workflows.

## Changes

- Added charmbracelet/tap to the list of Homebrew taps
- Added crush package for URL compression and sharing
- Added mise package for tool version management

## What are these packages?

### Crush
A utility for compressing and shortening URLs, making them more shareable while maintaining functionality.

### Mise
A fast and flexible tool version manager that works as a modern alternative to asdf. Mise allows you to:
- Manage multiple tool versions simultaneously
- Define environment-specific tool versions via mise.toml
- Automatically install and switch between tool versions
- Support for Node.js, Python, Ruby, Go, Java, Rust, and many other tools

## Installation

After merging, run the following to install:
```bash
brew bundle install
```

## Getting Started with Mise

Once installed, you can start using mise immediately:
```bash
mise --version
mise use node@20  # Install and use Node.js 20
mise exec python@3.12 -- python script.py  # Run with specific Python version
```

Learn more at: https://mise.jdx.dev/getting-started.html