### PR TITLE
feat: Add cmux - AI-assisted terminal multiplexer

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,7 @@
 # Taps
 tap "aws/tap" # AWS tools
 tap "charmbracelet/tap" # Charm shell tools and utilities
+tap "manaflow-ai/cmux" # Cmux - Terminal multiplexer with AI assistance
 tap "oven-sh/bun" # Bun JavaScript runtime
 
 # Command Line Tools & Development
@@ -87,6 +88,7 @@ cask "claude-code" # Claude Code - AI pair programming by Anthropic
 brew "gemini-cli" # Google Gemini CLI
 cask "codex" # OpenAI Codex application
 brew "opencode" # OpenCode - Terminal-based AI coding assistant
+cask "cmux" # Terminal multiplexer with AI assistance
 
 # macOS Applications
 cask "aldente" # macOS battery charge limiter

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This repository contains my personal dotfiles configuration, designed with modul
 - **SSH Key Organization**: Centralized SSH key management with migration and backup capabilities
 - **AI Prompts Management**: Organized system for managing AI prompts and context scripts by company/project
 - **AI Agent CLI Tools**: Support for Gemini, Claude, and Codex CLI tools with co-existence strategy
+- **Terminal Multiplexer with AI**: Cmux - AI-assisted terminal multiplexer for enhanced productivity
 - **Best Practices Documentation**: Comprehensive guides for modern development technologies and frameworks
 
 ## Structure
@@ -308,6 +309,7 @@ The dotfiles now include comprehensive terminal setup tools for an enhanced deve
 #### Terminal Multiplexers
 - **Tmux**: Terminal multiplexer for managing multiple sessions
 - **Zellij**: Modern terminal workspace with built-in layouts and plugins
+- **Cmux**: AI-assisted terminal multiplexer with intelligent session management
 
 #### Shell Enhancements
 - **Starship**: Cross-shell prompt customization with minimal, blazing-fast design
@@ -873,6 +875,30 @@ The configuration includes:
 - **tmux-notify** for desktop notifications
 - **tmux-powerline** for powerline status bar
 - **Custom scripts** for development workflows
+
+### Cmux - AI-Assisted Terminal Multiplexer
+
+Cmux is an AI-assisted terminal multiplexer that enhances productivity with intelligent session management and AI-powered features:
+
+```bash
+# Install via Homebrew (included in Brewfile)
+brew tap manaflow-ai/cmux
+brew install --cask cmux
+```
+
+**Features:**
+- **AI-Powered Assistance**: Integrated AI assistance for terminal commands and workflows
+- **Smart Session Management**: Intelligent session persistence and organization
+- **Seamless Integration**: Works alongside Tmux and other terminal tools
+- **Enhanced Productivity**: AI suggestions for common terminal tasks
+
+**Usage:**
+After installation, launch cmux from your terminal:
+```bash
+cmux
+```
+
+For more information, visit: https://github.com/manaflow-ai/cmux
 
 ### Raycast Productivity Launcher
 


### PR DESCRIPTION
## Summary

This PR adds cmux, an AI-assisted terminal multiplexer, to the dotfiles setup.

### Changes

- **Brewfile**: 
  - Added tap \manaflow-ai/cmux\
  - Added cask \cmux\ to AI Development Tools section

- **README.md**:
  - Added cmux to feature list
  - Added cmux to Terminal Multiplexers section
  - Added dedicated section with installation and usage instructions

### What is Cmux?

Cmux is an AI-assisted terminal multiplexer that enhances productivity with:
- AI-powered assistance for terminal commands
- Smart session management
- Seamless integration with existing terminal tools

### Installation

After merging, users can install cmux via:
\\\bash