### PR TITLE
Add zoxide init, mise support, and clean up Herd PHP config

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 elixir 1.18.1-otp-27
+erlang 27.2

--- a/.zshrc
+++ b/.zshrc
@@ -68,24 +68,6 @@ DOTFILES_DIR="$HOME/dotfiles"
 # Performance profiling (uncomment to debug slow startup)
 # zprof
 
-# Herd injected PHP 8.4 configuration.
-export HERD_PHP_84_INI_SCAN_DIR="/Users/gerwin/Library/Application Support/Herd/config/php/84/"
+# Herd injected PHP configuration.
+export HERD_PHP_INI_SCAN_DIR="$HOME/Library/Application Support/Herd/config/php/"
 
-
-# Herd injected PHP 8.3 configuration.
-export HERD_PHP_83_INI_SCAN_DIR="/Users/gerwin/Library/Application Support/Herd/config/php/83/"
-
-
-# Herd injected PHP 8.2 configuration.
-export HERD_PHP_82_INI_SCAN_DIR="/Users/gerwin/Library/Application Support/Herd/config/php/82/"
-
-
-# Herd injected PHP 8.1 configuration.
-export HERD_PHP_81_INI_SCAN_DIR="/Users/gerwin/Library/Application Support/Herd/config/php/81/"
-
-
-# Herd injected PHP 8.5 configuration.
-export HERD_PHP_85_INI_SCAN_DIR="/Users/gerwin/Library/Application Support/Herd/config/php/85/"
-
-# Added by Antigravity
-export PATH="/Users/gerwin/.antigravity/antigravity/bin:$PATH"

--- a/aliases.zsh
+++ b/aliases.zsh
@@ -27,6 +27,7 @@ if command -v bat &> /dev/null; then
 fi
 
 if command -v zoxide &> /dev/null; then
+    eval "$(zoxide init zsh)"
     alias cd='z'
 fi
 

--- a/exports.zsh
+++ b/exports.zsh
@@ -66,6 +66,12 @@ if [[ -d "$HOME/.rbenv" ]]; then
     export PATH="$HOME/.rbenv/bin:$PATH"
 fi
 
+# Mise (Version Manager)
+export MISE_DIR="$HOME/.local/share/mise"
+if [[ -d "$MISE_DIR" ]]; then
+    export PATH="$MISE_DIR/shims:$PATH"
+fi
+
 # Go
 export GOPATH="$HOME/go"
 export PATH="$GOPATH/bin:$PATH"


### PR DESCRIPTION
## Summary
- Add `eval "$(zoxide init zsh)"` to properly initialize zoxide shell integration
- Add mise (version manager) support in exports.zsh
- Clean up Herd PHP configuration by using the unified INI scan directory
- Add erlang to .tool-versions