### PR TITLE
Remove jetbrains-toolbox, appflowy, alt-tab, and aldente from dotfiles

### DIFF
--- a/.dotfiles-cask-ignore
+++ b/.dotfiles-cask-ignore
@@ -29,13 +29,10 @@
 # opera                      # Caskroom conflicts
 # firefox@developer-edition  # Version management issues
 # vivaldi                    # App source path issues
-# alt-tab                    # Occasional conflicts
-
 # Add your ignored casks below:
 # -----------------------------
 opera            # Gets stuck during upgrade
 skype
-alt-tab          # App source missing error
 arc              # App source missing error
 opera-air        # App source missing error
 whatsapp         # Already an App conflict

--- a/Brewfile
+++ b/Brewfile
@@ -89,9 +89,6 @@ cask "codex" # OpenAI Codex application
 brew "opencode" # OpenCode - Terminal-based AI coding assistant
 
 # macOS Applications
-cask "aldente" # macOS battery charge limiter
-cask "alt-tab" # Windows alt-tab on macOS
-cask "appflowy" # Open-source alternative to Notion
 cask "arc" # Recursively search directories for a regex pattern
 cask "discord" # Voice and text chat for communities
 cask "docker-desktop" # Application for building and sharing containerized applications
@@ -119,7 +116,6 @@ cask "google-chrome@canary" # Experimental version of Chrome
 cask "herd" # Laravel and PHP development environment
 cask "iina" # Modern media player for macOS
 cask "iterm2" # Terminal emulator for macOS
-cask "jetbrains-toolbox" # JetBrains IDE manager
 cask "jiggler" # Prevents sleep by jiggling the mouse
 cask "keyboardcleantool" # Temporarily disable keyboard for cleaning
 cask "lastpass" # Password manager

--- a/Brewfile.lock.commented
+++ b/Brewfile.lock.commented
@@ -60,9 +60,6 @@ brew "zsh"                                 # UNIX shell (command interpreter)
 brew "oven-sh/bun/bun"                     # Fast all-in-one JavaScript runtime
 
 # macOS Applications
-cask "aldente"                             # macOS battery charge limiter
-cask "alt-tab"                             # Windows alt-tab on macOS
-cask "appflowy"                            # Open-source alternative to Notion
 cask "arc"                                 # The internet computer browser
 cask "discord"                             # Voice and text chat for communities
 cask "docker-desktop"                      # Application for building and sharing containerized applications
@@ -89,8 +86,6 @@ cask "google-chrome@canary"                # Experimental version of Chrome
 cask "herd"                                # Laravel and PHP development environment
 cask "iina"                                # Modern media player for macOS
 cask "iterm2"                              # Terminal emulator for macOS
-cask "jetbrains-toolbox"                   # JetBrains IDE manager
-
 # Utilities
 cask "jiggler"                             # Prevents sleep by jiggling the mouse
 cask "keyboardcleantool"                   # Temporarily disable keyboard for cleaning

--- a/README.md
+++ b/README.md
@@ -233,7 +233,6 @@ cat .dotfiles-cask-ignore
 **Format** (inline comments supported):
 ```
 skype
-alt-tab          # App source missing error
 arc              # App source missing error
 logitech-options # Requires password prompt then fails
 ```

--- a/docs/CASK_REMEDIATION_GUIDE.md
+++ b/docs/CASK_REMEDIATION_GUIDE.md
@@ -83,7 +83,6 @@ arc                        # App source missing
 opera                      # Caskroom conflicts
 firefox@developer-edition  # Version management issues
 vivaldi                    # App source path issues
-alt-tab                    # Occasional conflicts
 ```
 
 ## 🔍 What Gets Logged

--- a/docs/issues/update-all-brew-casks.md
+++ b/docs/issues/update-all-brew-casks.md
@@ -10,7 +10,6 @@ Observed during `brew upgrade --cask --greedy` within the script:
 
 ```
 Error: Problems with multiple casks:
-alt-tab: It seems the App source '/Applications/AltTab.app' is not there.
 arc: It seems the App source '/Applications/Arc.app' is not there.
 firefox@developer-edition: It seems the App source '/Applications/Firefox Developer Edition.app' is not there.
 opera: It seems there is already an App at '/opt/homebrew/Caskroom/opera/118.0.5461.60/Opera.app'.
@@ -19,7 +18,7 @@ vivaldi: It seems the App source '/Applications/Vivaldi.app' is not there.
 
 ## Likely Causes
 
-- App bundles were moved/removed from `/Applications` after install (common for AltTab, Arc, Vivaldi, Firefox Dev Edition).
+- App bundles were moved/removed from `/Applications` after install (common for Arc, Vivaldi, Firefox Dev Edition).
 - Stale/partial installs in `Caskroom` (e.g., Opera) causing conflicts.
 - Upstream vendor download changed or rate-limited, or token changed.
 - Outdated/renamed tokens in `Brewfile` (e.g., Canary channel uses `google-chrome-canary`, not `google-chrome@canary`).
@@ -40,7 +39,7 @@ vivaldi: It seems the App source '/Applications/Vivaldi.app' is not there.
 
 ## Candidates To Review (remove/rename/skip)
 
-- `alt-tab`, `arc`, `vivaldi`, `firefox@developer-edition` — re-check tokens and reinstall behavior.
+- `arc`, `vivaldi`, `firefox@developer-edition` — re-check tokens and reinstall behavior.
 - `opera` — clean uninstall/reinstall to fix Caskroom conflict.
 - `google-chrome@canary` → `google-chrome-canary` (rename).
 - `logitech-options` — likely removable in favor of `logi-options+`.

--- a/scripts/update-all.sh
+++ b/scripts/update-all.sh
@@ -455,7 +455,6 @@ remediate_problem_casks() {
 
     # Known problematic casks observed in CI/local runs
     local candidates=(
-        alt-tab
         arc
         firefox@developer-edition
         vivaldi


### PR DESCRIPTION
## Summary
Removes the following casks from the dotfiles setup:
- `jetbrains-toolbox`
- `appflowy`
- `alt-tab`
- `aldente`

## Changes
- Removed the four casks from `Brewfile` and `Brewfile.lock.commented`
- Cleaned up `alt-tab` references from:
  - `.dotfiles-cask-ignore`
  - `scripts/update-all.sh` remediation candidates
  - `README.md`
  - `docs/CASK_REMEDIATION_GUIDE.md`
  - `docs/issues/update-all-brew-casks.md`
- Aligned all related documentation with the removed casks