### PR TITLE
feat: add rtk-ai and gh-stack CLI tools with install scripts and docs

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -87,6 +87,7 @@ cask "claude-code" # Claude Code - AI pair programming by Anthropic
 brew "gemini-cli" # Google Gemini CLI
 cask "codex" # OpenAI Codex application
 brew "opencode" # OpenCode - Terminal-based AI coding assistant
+brew "rtk" # rtk-ai - Token-optimized CLI proxy for Claude Code, Codex, and OpenCode
 
 # macOS Applications
 cask "arc" # Recursively search directories for a regex pattern

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- rtk-ai token optimization proxy and gh-stack CLI tools (#114)
+  - Added `brew "rtk"` to Brewfile
+  - Created `scripts/setup-rtk.sh` to install rtk and wire it into Claude Code, Codex, and OpenCode globally
+  - Created `scripts/setup-gh-stack.sh` to install the gh-stack extension and its agent skill (user scope) for Claude Code, Codex, and OpenCode
+  - Documented both in `docs/ai-tools/INSTALLATION.md` and README.md
+
 - Raycast productivity launcher to Brewfile and documentation
   - Added `cask "raycast"` to macOS Applications section
   - Created `docs/RAYCAST.md` with comprehensive setup guide

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository contains my personal dotfiles configuration, designed with modul
 - **Git Profile Management**: Manage multiple Git identities (personal, work) with SSH keys and GitHub CLI integration
 - **SSH Key Organization**: Centralized SSH key management with migration and backup capabilities
 - **AI Prompts Management**: Organized system for managing AI prompts and context scripts by company/project
-- **AI Agent CLI Tools**: Support for Gemini, Claude, and Codex CLI tools with co-existence strategy
+- **AI Agent CLI Tools**: Support for Gemini, Claude, Codex, and OpenCode CLI tools with co-existence strategy, plus `rtk-ai` (token optimization proxy) and `gh-stack` (stacked PRs) — see [docs/ai-tools/INSTALLATION.md](docs/ai-tools/INSTALLATION.md)
 - **Best Practices Documentation**: Comprehensive guides for modern development technologies and frameworks
 
 ## Structure
@@ -387,7 +387,7 @@ brew bundle dump --force --file=~/dotfiles/Brewfile
 
 ### Updating AI/LLM CLI Tools
 
-The dotfiles include automated updates for AI CLI tools like `gemini-cli`, `codex`, and `claude-code`:
+The dotfiles include automated updates for AI CLI tools like `gemini-cli`, `codex`, and `claude-code`, as well as the supporting `rtk` and `gh-stack` CLI extensions (see [docs/ai-tools/INSTALLATION.md](docs/ai-tools/INSTALLATION.md) for install/update/uninstall details):
 
 ```bash
 # Update AI tools as part of full system update

--- a/docs/ai-tools/INSTALLATION.md
+++ b/docs/ai-tools/INSTALLATION.md
@@ -1,6 +1,6 @@
 # AI CLI Tools Installation Guide
 
-This guide will help you install and configure Claude, Gemini, Codex, and OpenCode CLI tools on your system.
+This guide will help you install and configure Claude, Gemini, Codex, and OpenCode CLI tools on your system, plus the supporting `rtk-ai` and `gh-stack` CLI extensions.
 
 ## Quick Installation
 
@@ -54,6 +54,74 @@ Then run the setup script to configure API keys:
 
 ```bash
 ~/dotfiles/scripts/setup-ai-tools.sh
+```
+
+## Installing rtk-ai (Token Optimization Proxy)
+
+[rtk-ai](https://github.com/rtk-ai/rtk) is a token-optimized CLI proxy that filters and summarizes command output (git, find, grep, test runners, etc.) before it reaches an assistant's context, cutting token usage by up to ~90% on common commands.
+
+### Automated Installation (Recommended)
+
+```bash
+~/dotfiles/scripts/setup-rtk.sh
+```
+
+The script will:
+1. Install `rtk` globally via Homebrew (also included in the Brewfile — `brew bundle install` installs it too)
+2. Wire it into Claude Code (`rtk init -g --auto-patch`) — registers a `PreToolUse` Bash hook in `~/.claude/settings.json`
+3. Wire it into Codex CLI (`rtk init --codex -g`) — adds `~/.codex/RTK.md` and references it from `~/.codex/AGENTS.md`
+4. Wire it into OpenCode (`rtk init --opencode -g --auto-patch`) — installs `~/.config/opencode/plugins/rtk.ts`
+5. Skip any tool that isn't installed
+
+### Manual Installation
+
+```bash
+# Install globally
+brew install rtk
+
+# Wire into each assistant CLI you use
+rtk init -g --auto-patch          # Claude Code
+rtk init --codex -g               # Codex CLI
+rtk init --opencode -g --auto-patch  # OpenCode
+```
+
+### Verification
+
+```bash
+rtk --version
+rtk gain
+which rtk
+```
+
+## Installing gh-stack (Stacked PRs)
+
+[gh-stack](https://github.com/github/gh-stack) is a `gh` CLI extension for managing stacked branches and dependent pull requests, with an accompanying agent skill for creating/rebasing/syncing stacks from Claude Code, Codex, and OpenCode.
+
+### Automated Installation (Recommended)
+
+```bash
+~/dotfiles/scripts/setup-gh-stack.sh
+```
+
+The script will:
+1. Install the extension: `gh extension install github/gh-stack`
+2. Install the agent skill at user (global) scope for Claude Code, Codex, and OpenCode via `gh skill install github/gh-stack --agent <agent> --scope user`
+
+### Manual Installation
+
+```bash
+gh extension install github/gh-stack
+gh skill install github/gh-stack --agent claude-code --scope user
+gh skill install github/gh-stack --agent codex --scope user
+gh skill install github/gh-stack --agent opencode --scope user
+```
+
+### Verification
+
+```bash
+gh extension list
+gh skill list
+gh stack --help
 ```
 
 ## Getting API Keys
@@ -134,12 +202,15 @@ command -v claude && echo "Claude: ✓" || echo "Claude: ✗"
 command -v gemini && echo "Gemini: ✓" || echo "Gemini: ✗"
 command -v codex && echo "Codex: ✓" || echo "Codex: ✗"
 command -v opencode && echo "OpenCode: ✓" || echo "OpenCode: ✗"
+command -v rtk && echo "rtk: ✓" || echo "rtk: ✗"
+gh extension list | grep -q gh-stack && echo "gh-stack: ✓" || echo "gh-stack: ✗"
 
 # Check versions
 claude --version
 gemini --version
 codex --version
 opencode --version
+rtk --version
 ```
 
 ## Troubleshooting
@@ -188,6 +259,9 @@ brew upgrade --cask claude-code
 brew upgrade gemini-cli
 brew upgrade --cask codex
 brew upgrade opencode
+brew upgrade rtk
+gh extension upgrade github/gh-stack
+gh skill update --all
 ```
 
 ## Uninstallation
@@ -199,7 +273,11 @@ brew uninstall --cask claude-code
 brew uninstall gemini-cli
 brew uninstall --cask codex
 brew uninstall opencode
+brew uninstall rtk
+gh extension remove github/gh-stack
 ```
+
+To remove rtk's per-tool wiring: `rtk init -g --uninstall`, `rtk init --codex -g --uninstall`, `rtk init --opencode -g --uninstall`.
 
 Remove API keys from `~/.zshrc.private`:
 
@@ -220,6 +298,8 @@ nano ~/.zshrc.private
 - Main Documentation: `~/dotfiles/docs/ai-tools/AI.md`
 - Homebrew Issues: `brew doctor`
 - API Key Issues: Check provider's documentation
-- Script Issues: Review `~/dotfiles/scripts/setup-ai-tools.sh`
+- Script Issues: Review `~/dotfiles/scripts/setup-ai-tools.sh`, `~/dotfiles/scripts/setup-rtk.sh`, `~/dotfiles/scripts/setup-gh-stack.sh`
+- rtk-ai: https://github.com/rtk-ai/rtk
+- gh-stack: https://github.com/github/gh-stack
 
 For more information, see the main AI tools documentation or the AGENTS.md rule file in your dotfiles.

--- a/scripts/setup-gh-stack.sh
+++ b/scripts/setup-gh-stack.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# gh-stack Setup Script
+# Installs the gh-stack GitHub CLI extension (https://github.com/github/gh-stack)
+# and the corresponding agent skill for Claude Code, Codex, and OpenCode.
+
+set -e  # Exit on error
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+print_success() {
+    echo -e "${GREEN}✓${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}✗${NC} $1"
+}
+
+print_info() {
+    echo -e "${YELLOW}ℹ${NC} $1"
+}
+
+print_header() {
+    echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${BLUE}$1${NC}"
+    echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+}
+
+if ! command -v gh &> /dev/null; then
+    print_error "GitHub CLI (gh) is not installed. Run: brew install gh"
+    exit 1
+fi
+
+print_header "gh-stack Setup"
+echo
+
+# Install the gh-stack extension
+if gh extension list | grep -q "github/gh-stack"; then
+    print_success "gh-stack extension is already installed"
+else
+    print_info "Installing gh-stack extension..."
+    gh extension install github/gh-stack
+    print_success "gh-stack extension installed"
+fi
+
+echo
+
+# Install the gh-stack skill for each installed assistant CLI (user scope)
+for agent in claude-code codex opencode; do
+    print_info "Installing gh-stack skill for ${agent} (user scope)..."
+    if gh skill install github/gh-stack --agent "$agent" --scope user --force; then
+        print_success "gh-stack skill installed for ${agent}"
+    else
+        print_error "Failed to install gh-stack skill for ${agent}"
+    fi
+done
+
+echo
+print_header "Setup Complete"
+echo
+print_info "Verify with:"
+echo "  gh extension list"
+echo "  gh skill list"
+echo "  gh stack --help"
+echo
+print_success "gh-stack setup complete!"

--- a/scripts/setup-rtk.sh
+++ b/scripts/setup-rtk.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# rtk-ai Setup Script
+# Installs rtk (https://github.com/rtk-ai/rtk) globally and wires it into
+# Claude Code, Codex CLI, and OpenCode via `rtk init`.
+
+set -e  # Exit on error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+print_success() {
+    echo -e "${GREEN}✓${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}✗${NC} $1"
+}
+
+print_info() {
+    echo -e "${YELLOW}ℹ${NC} $1"
+}
+
+print_header() {
+    echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${BLUE}$1${NC}"
+    echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+}
+
+if [[ "$OSTYPE" != "darwin"* ]] && [[ "$OSTYPE" != "linux-gnu"* ]]; then
+    print_error "This script is intended for macOS and Linux only"
+    exit 1
+fi
+
+print_header "rtk-ai Setup"
+echo
+
+# Install rtk globally via Homebrew if missing
+if command -v rtk &> /dev/null; then
+    print_success "rtk is already installed ($(rtk --version))"
+else
+    print_info "Installing rtk via Homebrew..."
+    if command -v brew &> /dev/null; then
+        brew install rtk
+        print_success "rtk installed"
+    else
+        print_error "Homebrew not found. Install Homebrew first, then re-run this script."
+        exit 1
+    fi
+fi
+
+echo
+
+# Wire rtk into each installed assistant CLI
+if command -v claude &> /dev/null; then
+    print_header "Claude Code"
+    rtk init -g --auto-patch
+    print_success "rtk hook installed for Claude Code (global)"
+    echo
+else
+    print_info "Claude Code not installed, skipping (run: brew install --cask claude-code)"
+fi
+
+if command -v codex &> /dev/null; then
+    print_header "Codex CLI"
+    rtk init --codex -g
+    print_success "rtk AGENTS.md/RTK.md installed for Codex (global)"
+    echo
+else
+    print_info "Codex CLI not installed, skipping (run: brew install --cask codex)"
+fi
+
+if command -v opencode &> /dev/null; then
+    print_header "OpenCode"
+    rtk init --opencode -g --auto-patch
+    print_success "rtk plugin installed for OpenCode (global)"
+    echo
+else
+    print_info "OpenCode not installed, skipping (run: brew install opencode)"
+fi
+
+print_header "Setup Complete"
+echo
+print_info "Verify with:"
+echo "  rtk --version"
+echo "  rtk gain"
+echo "  which rtk"
+echo
+print_success "rtk-ai setup complete!"


### PR DESCRIPTION
Closes #114

## Summary

Adds two supporting CLI tools to the dotfiles setup:

- **[rtk-ai](https://github.com/rtk-ai/rtk)** — token-optimized CLI proxy, wired globally and into Claude Code, Codex CLI, and OpenCode
- **[gh-stack](https://github.com/github/gh-stack)** — `gh` extension for stacked PRs, plus its agent skill installed at user (global) scope for Claude Code, Codex, and OpenCode

Both are installed via new idempotent setup scripts and documented in `docs/ai-tools/INSTALLATION.md` and `README.md`.

## Before / After

**Before:**
- `rtk` had no presence in the repo: not in the `Brewfile`, no install script, no docs. Anyone wanting it had to know it exists, find the right `rtk init` flags for each of Claude Code/Codex/OpenCode, and wire it manually.
- `gh-stack` had no presence in the repo either — no Brewfile/script/doc reference, despite the extension and skill already being usable via `gh` directly.

**After:**
- `Brewfile` installs `rtk` alongside the other AI Development Tools.
- `scripts/setup-rtk.sh` installs `rtk` (if missing) and runs `rtk init -g --auto-patch` / `rtk init --codex -g` / `rtk init --opencode -g --auto-patch`, skipping any assistant CLI that isn't installed.
- `scripts/setup-gh-stack.sh` installs the `gh-stack` extension and runs `gh skill install github/gh-stack --agent <agent> --scope user` for claude-code, codex, and opencode.
- `docs/ai-tools/INSTALLATION.md` gets two new sections (automated + manual install, verification, update, uninstall) for both tools, and the existing verification/update/uninstall command blocks are extended to include them.
- `README.md` and `CHANGELOG.md` reference the additions so they're discoverable from the top-level docs, not just buried in `docs/ai-tools/`.

## Files Changed

| File | Purpose |
|---|---|
| `Brewfile` | Add `brew "rtk"` global install |
| `scripts/setup-rtk.sh` (new) | Install + wire rtk into Claude Code, Codex, OpenCode |
| `scripts/setup-gh-stack.sh` (new) | Install gh-stack extension + skill (user scope, 3 agents) |
| `docs/ai-tools/INSTALLATION.md` | New sections + updated verify/update/uninstall blocks |
| `README.md` | Pointer from top-level feature bullet + update-tools section |
| `CHANGELOG.md` | Unreleased entry |

## Testing

Both scripts were executed directly on a machine that already had `rtk` and the `gh-stack` extension/skill installed manually, confirming:
- Correct "already installed" detection (no duplicate `brew install` / `gh extension install` calls)
- `rtk init -g --auto-patch` correctly reports the existing Claude Code hook and re-confirms it
- `rtk init --codex -g` correctly resolves `~/.codex/RTK.md` and the `AGENTS.md` reference
- `rtk init --opencode -g --auto-patch` correctly resolves the OpenCode plugin path
- `gh skill install ... --scope user` for claude-code, codex, and opencode all succeeded and are visible in `gh skill list`
- `bash -n` syntax check passed on both new scripts

Not tested: a clean machine with none of these tools pre-installed (i.e., the actual `brew install rtk` / `gh extension install github/gh-stack` code paths were not exercised, only the "already installed" branches).

## Confidence Scorecard

| Area | Confidence | Notes |
|---|---|---|
| rtk global install (Brewfile) | High | Confirmed `rtk` is an official `homebrew-core` formula, no tap needed |
| rtk → Claude Code wiring | High | Verified live against `rtk init -g --auto-patch`; matches this machine's existing hook config exactly |
| rtk → Codex wiring | High | Verified live; matches this machine's existing `~/.codex/RTK.md` setup exactly |
| rtk → OpenCode wiring | High | Verified live; matches this machine's existing `~/.config/opencode/plugins/rtk.ts` exactly |
| gh-stack extension install | High | Verified idempotent via `gh extension list` |
| gh-stack skill install (3 agents, user scope) | High | Verified via `gh skill list`; moved claude-code from project-only to also user scope |
| Docs alignment (no drift) | Medium-High | Manually cross-checked all four install targets are mentioned consistently in `INSTALLATION.md`; not linted |
| Fresh-machine install path | Medium | `brew install rtk` / `gh extension install github/gh-stack` code paths are straightforward but not exercised on this machine (both were already installed) |

## Regressions / Implementation Gaps vs. Issue Requirements

- **No regressions**: changes are additive only — no existing Brewfile lines, scripts, or docs were removed or altered beyond the sections shown above.
- **Gap**: `gh skill install` is explicitly marked `(preview)` by GitHub's CLI and "subject to change without notice." The `setup-gh-stack.sh` script depends on its current flag surface (`--agent`, `--scope`, `--force`); a future `gh` release could change this without warning.
- **Gap**: Neither new script is wired into `setup-test.sh` or `scripts/update-all.sh` — this matches the existing precedent (`scripts/setup-ai-tools.sh` isn't wired into either either), so it's consistent with current conventions rather than a regression, but it does mean these tools won't get pulled in automatically by `update-all.sh --ai-tools-only`.
- **Gap**: Not verified on Linux — both scripts check `$OSTYPE` for `linux-gnu*` and should work (rtk supports Linux), but this was only tested on macOS.
- **Out of scope (not attempted)**: wiring rtk/gh-stack into `scripts/setup-ai-tools.sh`'s interactive API-key flow — that script is specifically about LLM provider API keys, which don't apply to either tool, so it was left untouched rather than force-fit.
